### PR TITLE
#16 [FEAT] 하단에서 올라오는 모달 컴포넌트를 퍼블리싱합니다.

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <div id="modal-overlay"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/components/ui/Modal/Modal.styles.ts
+++ b/src/components/ui/Modal/Modal.styles.ts
@@ -9,7 +9,14 @@ const slideUp = keyframes`
   }
 `;
 
-export const ModalOverlay = styled.div<{ $closing: boolean }>`
+export const ModalOverlay = styled.div.attrs<{
+  $closing: boolean;
+  $translateY: number;
+}>(props => ({
+  style: {
+    backgroundColor: `rgba(0, 0, 0, ${Math.max(0.5 - props.$translateY / window.innerHeight, 0)})`,
+  },
+}))`
   position: fixed;
   top: 0;
   bottom: 0;
@@ -22,6 +29,7 @@ export const ModalOverlay = styled.div<{ $closing: boolean }>`
   justify-content: center;
   align-items: flex-end;
   z-index: 1000;
+  transition: background-color 0.2s ease-out;
 `;
 
 export const ModalContainer = styled.div.attrs<{

--- a/src/components/ui/Modal/Modal.styles.ts
+++ b/src/components/ui/Modal/Modal.styles.ts
@@ -1,0 +1,66 @@
+import styled, { keyframes, css } from 'styled-components';
+
+const slideUp = keyframes`
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+`;
+
+export const ModalOverlay = styled.div<{ $closing: boolean }>`
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100%;
+  max-width: var(--max-width);
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  z-index: 1000;
+`;
+
+export const ModalContainer = styled.div<{
+  $translateY: number;
+  $closing: boolean;
+}>`
+  width: 100%;
+  height: 75vh;
+  display: flex;
+  flex-direction: column;
+  transform: translateY(${props => props.$translateY}px);
+  transition: transform 0.2s ease-out;
+  ${props =>
+    !props.$closing &&
+    css`
+      animation: ${slideUp} 0.2s ease-out;
+    `}
+`;
+
+export const ModalHeader = styled.div`
+  padding: var(--spacing-2) var(--spacing-3);
+  background-color: var(--color-white);
+  border-top-left-radius: var(--radius-xl);
+  border-top-right-radius: var(--radius-xl);
+  position: relative;
+  border-bottom: 1px solid var(--color-gray-300);
+`;
+
+export const SwipeIndicator = styled.div`
+  width: 40px;
+  height: 5px;
+  background-color: var(--color-gray-500);
+  border-radius: var(--radius-full);
+  margin: var(--spacing-1) auto;
+`;
+
+export const ModalContent = styled.div`
+  flex: 1 1 0;
+  background-color: var(--color-white);
+  padding: var(--spacing-4);
+  overflow-y: auto;
+`;

--- a/src/components/ui/Modal/Modal.styles.ts
+++ b/src/components/ui/Modal/Modal.styles.ts
@@ -24,15 +24,18 @@ export const ModalOverlay = styled.div<{ $closing: boolean }>`
   z-index: 1000;
 `;
 
-export const ModalContainer = styled.div<{
+export const ModalContainer = styled.div.attrs<{
   $translateY: number;
   $closing: boolean;
-}>`
+}>(props => ({
+  style: {
+    transform: `translateY(${props.$translateY}px)`,
+  },
+}))`
   width: 100%;
   height: 75vh;
   display: flex;
   flex-direction: column;
-  transform: translateY(${props => props.$translateY}px);
   transition: transform 0.2s ease-out;
   ${props =>
     !props.$closing &&

--- a/src/components/ui/Modal/index.tsx
+++ b/src/components/ui/Modal/index.tsx
@@ -51,7 +51,11 @@ const Modal = ({ isOpen, onClose, children }: ModalProps) => {
   if (!isOpen) return null;
 
   return ReactDOM.createPortal(
-    <S.ModalOverlay $closing={isClosing} onClick={closeAnimation}>
+    <S.ModalOverlay
+      $closing={isClosing}
+      $translateY={translateY}
+      onClick={closeAnimation}
+    >
       <S.ModalContainer
         id="modal-container"
         onClick={e => e.stopPropagation()}

--- a/src/components/ui/Modal/index.tsx
+++ b/src/components/ui/Modal/index.tsx
@@ -16,13 +16,30 @@ const Modal = ({ isOpen, onClose, children }: ModalProps) => {
   });
   const modalRoot = document.getElementById('modal-overlay');
 
+  // 모달이 열릴 때 스크롤 방지
+  const preventScroll = () => {
+    const currentScrollY = window.scrollY;
+    document.body.style.position = 'fixed';
+    document.body.style.width = '100%';
+    document.body.style.top = `-${currentScrollY}px`;
+    document.body.style.overflow = 'scroll';
+    return currentScrollY;
+  };
+
+  // 모달이 닫힐 때 스크롤 허용
+  const allowScroll = (scrollY: number) => {
+    document.body.style.position = '';
+    document.body.style.width = '';
+    document.body.style.top = '';
+    document.body.style.overflow = '';
+    window.scrollTo(0, scrollY);
+  };
+
   useEffect(() => {
     if (isOpen) {
-      document.body.style.overflow = 'hidden';
+      const scrollY = preventScroll();
+      return () => allowScroll(scrollY);
     }
-    return () => {
-      document.body.style.overflow = 'unset';
-    };
   }, [isOpen]);
 
   useEffect(() => {

--- a/src/components/ui/Modal/index.tsx
+++ b/src/components/ui/Modal/index.tsx
@@ -1,0 +1,55 @@
+import { useEffect } from 'react';
+import ReactDOM from 'react-dom';
+
+import { useDrag } from '@/hooks/useDrag';
+import * as S from './Modal.styles';
+
+type ModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+};
+
+const Modal = ({ isOpen, onClose, children }: ModalProps) => {
+  const { translateY, isClosing, handlers, closeAnimation } = useDrag({
+    onClose,
+  });
+  const modalRoot = document.getElementById('modal-overlay');
+
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    }
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    const handleMouseLeave = handlers.onMouseUp;
+    document.addEventListener('mouseleave', handleMouseLeave);
+    return () => document.removeEventListener('mouseleave', handleMouseLeave);
+  }, [handlers.onMouseUp]);
+
+  if (!isOpen) return null;
+
+  return ReactDOM.createPortal(
+    <S.ModalOverlay $closing={isClosing} onClick={closeAnimation}>
+      <S.ModalContainer
+        id="modal-container"
+        onClick={e => e.stopPropagation()}
+        $translateY={translateY}
+        $closing={isClosing}
+        {...handlers}
+      >
+        <S.ModalHeader>
+          <S.SwipeIndicator />
+        </S.ModalHeader>
+        <S.ModalContent>{children}</S.ModalContent>
+      </S.ModalContainer>
+    </S.ModalOverlay>,
+    modalRoot as HTMLElement,
+  );
+};
+
+export default Modal;

--- a/src/constants/constant.ts
+++ b/src/constants/constant.ts
@@ -4,3 +4,5 @@ export const ROUTER_PATH = {
   SALARY: '/salary',
   PROFILE: '/profile',
 };
+
+export const DRAG_CLOSE_THRESHOLD = 250;

--- a/src/hooks/useDrag.ts
+++ b/src/hooks/useDrag.ts
@@ -1,0 +1,64 @@
+import { useCallback, useRef, useState, useEffect } from 'react';
+
+import { DragHandlers } from '@/types/drag-handler';
+import { DRAG_CLOSE_THRESHOLD } from '@/constants/constant';
+
+type UseDragProps = {
+  onClose: () => void;
+};
+
+const useDrag = ({ onClose }: UseDragProps) => {
+  const [translateY, setTranslateY] = useState(0); // 모달의 y축 위치값
+  const [isClosing, setIsClosing] = useState(false); // 모달이 닫히는 중인지 여부
+  const startPosition = useRef(0); // 드래그 시작 지점
+  const isDragging = useRef(false); // 드래그 중인지 여부
+
+  const closeAnimation = useCallback(() => {
+    setIsClosing(true);
+    setTranslateY(window.innerHeight); // 화면 아래로 내림
+    setTimeout(onClose, 200); // 애니메이션이 끝나면 모달을 닫음
+  }, [onClose]);
+
+  const handleDragStart = useCallback((clientY: number) => {
+    startPosition.current = clientY;
+    isDragging.current = true;
+  }, []);
+
+  const handleDragMove = useCallback((clientY: number) => {
+    if (!isDragging.current) return;
+
+    const diff = clientY - startPosition.current;
+    if (diff > 0) {
+      setTranslateY(diff);
+    }
+  }, []);
+
+  const handleDragEnd = useCallback(() => {
+    if (!isDragging.current) return;
+
+    isDragging.current = false;
+    if (translateY > DRAG_CLOSE_THRESHOLD) {
+      closeAnimation();
+    } else {
+      setTranslateY(0); // 취소 시에만 원위치로
+    }
+  }, [closeAnimation, translateY]);
+
+  useEffect(() => {
+    setTranslateY(0);
+    setIsClosing(false);
+  }, [onClose]);
+
+  const handlers: DragHandlers = {
+    onTouchStart: e => handleDragStart(e.touches[0].clientY),
+    onTouchMove: e => handleDragMove(e.touches[0].clientY),
+    onTouchEnd: handleDragEnd,
+    onMouseDown: e => handleDragStart(e.clientY),
+    onMouseMove: e => handleDragMove(e.clientY),
+    onMouseUp: handleDragEnd,
+  };
+
+  return { translateY, isClosing, handlers, closeAnimation };
+};
+
+export { useDrag };

--- a/src/types/drag-handler.d.ts
+++ b/src/types/drag-handler.d.ts
@@ -1,0 +1,9 @@
+/* eslint-disable */
+export type DragHandlers = {
+  onTouchStart: (e: React.TouchEvent<HTMLDivElement>) => void;
+  onTouchMove: (e: React.TouchEvent<HTMLDivElement>) => void;
+  onTouchEnd: () => void;
+  onMouseDown: (e: React.MouseEvent<HTMLDivElement>) => void;
+  onMouseMove: (e: React.MouseEvent<HTMLDivElement>) => void;
+  onMouseUp: () => void;
+};


### PR DESCRIPTION
## 🚀 Related Issues

- 이슈 넘버 #16 

## ☑️ Task Details

- 아래에서 위로 올라오는 애니메이션을 구현했어요. (0.2초의 시간이 걸려요.)
- 드래그로 모달을 내릴 수 있도록 했어요. (250px 이상 내리고 손을 떼면 모달이 내려가요.)
- 오버레이 클릭 시 닫히도록 했어요. (이 때도 바로 없어지는게 아닌 애니메이션으로 내려가도록 했어요.)
- 모달이 열려있을 때 배경 스크롤 방지했어요.
- React Portal을 사용하여 모달을 body에 직접 마운트해요.
- 모달이 올라오고 내려갈 때 오버레이 색상이 모달의 높이에 따라 색상 투명도를 추가했어요.
- 드래그 관련 로직은 훅으로 분리했어요.

## 📂 References

https://github.com/user-attachments/assets/8b7e2247-f251-44d4-8fd3-85497fc9695b

## 💞 Review Requirements

- 전체적으로 **인스타그램 댓글창**을 참고했어요. 인스타그램도 위 모달처럼 동작하더라구요. 
- 오버레이 색상 투명도도 신경썼습니다.

## 😠 트러블슈팅

전체적으로 애니메이션 라이브러리 없이 쓰려다 보니 많이 어려웠어요. 그래도 생성형 ai의 도움을 받으며 하나씩 완성할 수 있었던 것 같아요.

그 중 겪었던 트러블슈팅 하나를 소개하려고 해요.

### 미친듯한 리렌더링?

얼추 모달이 만들어진 것 같다고 생각하고 개발자 도구를 확인했는데

![image](https://github.com/user-attachments/assets/e26111c9-6f08-49a5-bf89-6440a0d54102)

**`warning` 파티.**

```js
export const ModalContainer = styled.div<{
 $translateY: number;
 $closing: boolean;
}>`
 transform: translateY(${(props) => props.$translateY}px);
...
`
```

이렇게 했었는데 이 방법은 계속해서 props가 바뀔 때마다 컴포넌트 자체가 리렌더링이 발생했어요. 

https://github.com/user-attachments/assets/fdabc3de-2c5e-4316-84f7-ca3678677840

이렇게 클래스 이름이 계속해서 변경됐었죠.

### 어떻게 해결하지?

다행히, 사진에 힌트가 나와있었어요. `attrs`를 사용하라고 하네요. 

https://github.com/user-attachments/assets/2e2a9d4e-3113-49dc-83e5-35b51354b6c1

```js
export const ModalContainer = styled.div.attrs<{
  $translateY: number;
  $closing: boolean;
}>(props => ({
  style: {
    transform: `translateY(${props.$translateY}px)`,
  },
}))` ~ styles code...
```
위와 같이 style로 지정을 해줬더니 계속 드래그를 해도 warning이 발생하지 않았어요. 

### 왜 이런 차이가 발생하지?

styled-components에서 일반적으로 props를 사용해 스타일을 동적으로 사용하면 props가 변경될 때마다 새로운 스타일이 생성되고 컴포넌트가 리렌더링된다고 해요.

하지만 `attrs`를 사용하면 style 객체를 직접 조작하기 때문에, React의 Virtual DOM 단계를 거치지 않고 실제 DOM의 style 속성만 업데이트된다고 해요. 

특히 드래그나 뭐 빈번하게 값이 변하는 경우에는 `attrs`를 사용하는 것이 효율적이에요. 
