### PR TITLE
#49 [FEAT] 헤더 컴포넌트에 로고를 포함하여 퍼블리싱합니다.

### DIFF
--- a/src/components/header/Header.styles.ts
+++ b/src/components/header/Header.styles.ts
@@ -1,0 +1,14 @@
+import styled from 'styled-components';
+
+import headerLogo from '@/assets/logo.svg';
+
+export const Header = styled.header`
+  padding: var(--spacing-3) var(--spacing-2);
+`;
+
+export const HeaderLogo = styled.img.attrs({
+  src: headerLogo,
+  alt: 'Day Us Logo',
+})`
+  width: 100px;
+`;

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,0 +1,16 @@
+import { Link } from 'react-router-dom';
+
+import { ROUTER_PATH } from '@/constants/constant';
+import * as S from './Header.styles';
+
+const Header = () => {
+  return (
+    <S.Header>
+      <Link to={ROUTER_PATH.HOME}>
+        <S.HeaderLogo />
+      </Link>
+    </S.Header>
+  );
+};
+
+export default Header;

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -2,10 +2,12 @@ import { Outlet } from 'react-router-dom';
 
 import NavBar from '@/components/ui/Navbar';
 import * as S from './Layout.styles';
+import Header from '@/components/header/Header';
 
 const Layout = () => {
   return (
     <S.Container>
+      <Header />
       <Outlet />
       <NavBar />
     </S.Container>


### PR DESCRIPTION
## 🚀 Related Issues

- 이슈 넘버 #49 

## ☑️ Task Details

- 로고를 넣어 헤더 컴포넌트를 만들었어요.
- 모든 페이지에서 적용되도록 Outlet 위에 넣었어요. 

## 📂 References

- 스크린샷이나 레퍼런스를 넣어주세요!

## 💞 Review Requirements

- Layout에서 양 옆 패딩 뺄거라 header에서 양 옆 패딩 `var(--spacing-2)` 넣었어요.
