### PR TITLE
#104 [FIX] 풀모달을 사용 시 발생하는 무한 렌더링 문제를 해결합니다. 

### DIFF
--- a/src/components/calendar/MainCalendar.tsx
+++ b/src/components/calendar/MainCalendar.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 
+import { useNavigate } from 'react-router-dom';
 import { Calendar, dayjsLocalizer } from 'react-big-calendar';
 import 'react-big-calendar/lib/css/react-big-calendar.css';
 import dayjs from 'dayjs';
@@ -20,6 +21,7 @@ dayjs.locale('ko');
 const localizer = dayjsLocalizer(dayjs);
 
 const MainCalendar = () => {
+  const navigation = useNavigate();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [currentSchedule, setCurrentSchedule] = useState<IEventList | null>(
     null,
@@ -71,6 +73,7 @@ const MainCalendar = () => {
   ) => {
     handleEdit(eventId, updatedSchedule);
     closeIdModal();
+    navigation(-1);
     setCurrentSchedule(null);
   };
 

--- a/src/components/ui/ModalFull/index.tsx
+++ b/src/components/ui/ModalFull/index.tsx
@@ -1,11 +1,12 @@
 import { useCallback, useEffect } from 'react';
 import ReactDOM from 'react-dom';
+
+import { useLocation, useNavigate } from 'react-router-dom';
+
 import * as S from './ModalFull.style';
 import PageNav from '../PageNav';
-import { useLocation, useNavigate } from 'react-router-dom';
 import { useScrollLock } from '@/hooks/useScrollLock';
 import { useToggleModal } from '@/hooks/useToggleModal';
-import { ADD_SCHEDULE_MODAL_ID } from '@/constants/constant';
 
 type ModalProps = {
   id: string;
@@ -27,7 +28,7 @@ const ModalFull = ({
   const navigate = useNavigate();
   const { pathname } = useLocation();
 
-  const { closeIdModal } = useToggleModal({ modalId: ADD_SCHEDULE_MODAL_ID });
+  const { closeIdModal } = useToggleModal({ modalId: id });
 
   useScrollLock({ isOpen });
 
@@ -36,17 +37,21 @@ const ModalFull = ({
     closeIdModal();
   }, [navigate, closeIdModal]);
 
+  const handlePopState = useCallback(() => {
+    closeIdModal();
+  }, [closeIdModal]);
+
   useEffect(() => {
     if (isOpen) {
       navigate(`${pathname}?modal=${id}`);
 
-      window.addEventListener('popstate', () => closeIdModal());
+      window.addEventListener('popstate', handlePopState);
 
       return () => {
-        window.removeEventListener('popstate', () => closeIdModal());
+        window.removeEventListener('popstate', handlePopState);
       };
     }
-  }, [isOpen, navigate, pathname, id, closeIdModal]);
+  }, [isOpen, navigate, pathname, id, handlePopState]);
 
   if (!isOpen) return null;
 

--- a/src/hooks/useToggleModal.ts
+++ b/src/hooks/useToggleModal.ts
@@ -1,3 +1,5 @@
+import { useCallback } from 'react';
+
 import { RootState } from '@/store';
 import { closeModal, openModal } from '@/store/slices/modalToggleSlice';
 import { useDispatch, useSelector } from 'react-redux';
@@ -11,16 +13,21 @@ const useToggleModal = ({ modalId }: useToggleModalProps) => {
   const isOpen = useSelector((state: RootState) => state.modal[modalId]);
   const dispatch = useDispatch();
 
-  const openIdModal = () => dispatch(openModal(modalId));
-  const closeIdModal = () => dispatch(closeModal(modalId));
+  const openIdModal = useCallback(() => {
+    dispatch(openModal(modalId));
+  }, [dispatch, modalId]);
 
-  const toggleModal = () => {
+  const closeIdModal = useCallback(() => {
+    dispatch(closeModal(modalId));
+  }, [dispatch, modalId]);
+
+  const toggleModal = useCallback(() => {
     if (isOpen) {
-      openIdModal();
-    } else {
       closeIdModal();
+    } else {
+      openIdModal();
     }
-  };
+  }, [isOpen, openIdModal, closeIdModal]);
 
   return { isOpen, openIdModal, closeIdModal, toggleModal };
 };


### PR DESCRIPTION
## 🚀 Related Issues

- 이슈 넘버 #104 

## ☑️ Task Details

- `popState` 이벤트 핸들러를 `useCallback`을 사용해 메모이제이션했어요.
- `useToggleModal` 훅에서 상태 변경 함수를 `useCallback`으로 메모이제이션했어요.
- `toggleModal` 함수의 로직 오류를 수정했어요. → `isOpen` 상태에 따라 반대로 동작하는 것을 수정했어요. → ScheduleList에서 버튼을 눌렀을 때 열리지 않길래 로직 수정을 한겁니다.

## 📂 References

- 스크린샷이나 레퍼런스를 넣어주세요!

## 💞 Review Requirements

### 원인

```js
useEffect(() => {
  if (isOpen) {
    navigate(`${pathname}?modal=${id}`);
    window.addEventListener('popstate', () => closeIdModal()); // 인라인 함수
    return () => {
      window.removeEventListener('popstate', () => closeIdModal()); // 새로운 인라인 함수
    };
  }
}, [isOpen, navigate, pathname, id, closeIdModal]);
```
위처럼 `useEffect` 내부의 이벤트 리스너에서 인라인 함수를 사용한 것이 문제가 됐어요.
여기서 사용된 인라인 함수는 매 렌더링마다 새로운 참조를 가져서 `cleanup` 함수에서 제거가 되지 않았어요. 
그 결과로 매 렌더링마다 새로 생성되어 의존성 배열에 포함된 `closeIdModal`이 계속해서 변경되었어요.