### PR TITLE
#106 [REFACTOR] 풀모달을 홈페이지에서 관리하도록 리팩토링합니다. 

### DIFF
--- a/src/components/calendar/MainCalendar.tsx
+++ b/src/components/calendar/MainCalendar.tsx
@@ -1,6 +1,5 @@
 import { useMemo, useState } from 'react';
 
-import { useNavigate } from 'react-router-dom';
 import { Calendar, dayjsLocalizer } from 'react-big-calendar';
 import 'react-big-calendar/lib/css/react-big-calendar.css';
 import dayjs from 'dayjs';
@@ -8,35 +7,21 @@ import 'dayjs/locale/ko';
 
 import * as S from './MainCalendar.style';
 import Modal from '../ui/Modal';
-import ModalFull from '../ui/ModalFull';
-import EditScheduleModal from '../edit-schedule-modal/EditScheduleModal';
 import ScheduleList from '../schedule/schedule-list/ScheduleList';
 import CustomToolbar from './CustomToolbar';
-import { IEventList } from '@/types/calendar';
-import { useCalendarEvents } from '@/hooks/useCalendarEvents';
-import { useToggleModal } from '@/hooks/useToggleModal';
-import { EDIT_SCHEDULE_MODAL_ID } from '@/constants/constant';
+import { IEventList, IMainCalendarProps } from '@/types/calendar';
 
 dayjs.locale('ko');
 const localizer = dayjsLocalizer(dayjs);
 
-const MainCalendar = () => {
-  const navigation = useNavigate();
+const MainCalendar = ({
+  processedEvents,
+  selectedEvents,
+  onEditSchedule,
+  onDateSelect,
+  onDelete,
+}: IMainCalendarProps) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [currentSchedule, setCurrentSchedule] = useState<IEventList | null>(
-    null,
-  );
-
-  const { isOpen, openIdModal, closeIdModal } = useToggleModal({
-    modalId: EDIT_SCHEDULE_MODAL_ID,
-  });
-  const {
-    handleDateSelect,
-    handleDelete,
-    handleEdit,
-    processedEvents,
-    selectedEvents,
-  } = useCalendarEvents();
 
   const components = useMemo(
     () => ({
@@ -53,28 +38,13 @@ const MainCalendar = () => {
   });
 
   const handleSelectCell = (cellInfo: { start: Date; end: Date }) => {
-    handleDateSelect(cellInfo);
+    onDateSelect(cellInfo);
     setIsModalOpen(true);
   };
 
   const handleSelectEvent = (event: IEventList) => {
-    handleDateSelect({ start: event.start!, end: event.end! });
+    onDateSelect({ start: event.start!, end: event.end! });
     setIsModalOpen(true);
-  };
-
-  const handleOpenEditModal = (schedule: IEventList) => {
-    setCurrentSchedule(schedule);
-    openIdModal();
-  };
-
-  const handleEditSchedule = (
-    eventId: string,
-    updatedSchedule: Partial<IEventList>,
-  ) => {
-    handleEdit(eventId, updatedSchedule);
-    closeIdModal();
-    navigation(-1);
-    setCurrentSchedule(null);
   };
 
   return (
@@ -96,21 +66,10 @@ const MainCalendar = () => {
       <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)}>
         <ScheduleList
           schedules={selectedEvents}
-          onDelete={handleDelete}
-          onOpenEditModal={handleOpenEditModal}
+          onDelete={onDelete}
+          onEditSchedule={onEditSchedule}
         />
       </Modal>
-
-      <ModalFull
-        id={EDIT_SCHEDULE_MODAL_ID}
-        isOpen={isOpen}
-        navText="일정 수정"
-      >
-        <EditScheduleModal
-          schedule={currentSchedule!}
-          onEdit={handleEditSchedule}
-        />
-      </ModalFull>
     </S.Container>
   );
 };

--- a/src/components/schedule/schedule-item/ScheduleItem.tsx
+++ b/src/components/schedule/schedule-item/ScheduleItem.tsx
@@ -8,13 +8,16 @@ import Button from '@/components/ui/Button/Button';
 import { ScheduleItemProps } from '@/types/schedule';
 import { formatDate } from '@/utils/formatDate';
 import { compareDateRange } from '@/utils/compareDateRange';
+import { useToggleModal } from '@/hooks/useToggleModal';
+import { EDIT_SCHEDULE_MODAL_ID } from '@/constants/constant';
 
 const ScheduleItem = ({
   schedule,
   onDelete,
-  onOpenEditModal,
+  onEditSchedule,
 }: ScheduleItemProps) => {
   const [showDeleteButton, setShowDeleteButton] = useState(false);
+  const { openIdModal } = useToggleModal({ modalId: EDIT_SCHEDULE_MODAL_ID });
 
   if (!schedule) return null;
 
@@ -25,6 +28,12 @@ const ScheduleItem = ({
 
   const handleCancel = () => {
     setShowDeleteButton(false);
+  };
+
+  const handleEdit = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onEditSchedule(schedule);
+    openIdModal();
   };
 
   const toggleTrashButton = (event: React.MouseEvent) => {
@@ -45,7 +54,7 @@ const ScheduleItem = ({
   return (
     <>
       <S.ScheduleItemWrapper>
-        <S.ScheduleItem onClick={() => onOpenEditModal(schedule)}>
+        <S.ScheduleItem onClick={handleEdit}>
           <S.ScheduleInfo>
             <S.ColorDot $bgColor={schedule.color.bgColor} />
             <S.ScheduleText>

--- a/src/components/schedule/schedule-list/ScheduleList.tsx
+++ b/src/components/schedule/schedule-list/ScheduleList.tsx
@@ -7,7 +7,7 @@ import { ADD_SCHEDULE_MODAL_ID } from '@/constants/constant';
 const ScheduleList = ({
   schedules = [],
   onDelete,
-  onOpenEditModal,
+  onEditSchedule,
 }: ScheduleListProps) => {
   const { toggleModal } = useToggleModal({ modalId: ADD_SCHEDULE_MODAL_ID });
 
@@ -32,7 +32,7 @@ const ScheduleList = ({
               key={schedule.eventId}
               schedule={schedule}
               onDelete={onDelete}
-              onOpenEditModal={onOpenEditModal}
+              onEditSchedule={onEditSchedule}
             />
           ))
         )}

--- a/src/hooks/useToggleModal.ts
+++ b/src/hooks/useToggleModal.ts
@@ -1,5 +1,7 @@
 import { useCallback } from 'react';
 
+import { useNavigate } from 'react-router-dom';
+
 import { RootState } from '@/store';
 import { closeModal, openModal } from '@/store/slices/modalToggleSlice';
 import { useDispatch, useSelector } from 'react-redux';
@@ -10,6 +12,7 @@ type useToggleModalProps = {
 
 // 모달 여닫기(redux로 state 관리)
 const useToggleModal = ({ modalId }: useToggleModalProps) => {
+  const navigate = useNavigate();
   const isOpen = useSelector((state: RootState) => state.modal[modalId]);
   const dispatch = useDispatch();
 
@@ -19,7 +22,8 @@ const useToggleModal = ({ modalId }: useToggleModalProps) => {
 
   const closeIdModal = useCallback(() => {
     dispatch(closeModal(modalId));
-  }, [dispatch, modalId]);
+    navigate(-1);
+  }, [dispatch, modalId, navigate]);
 
   const toggleModal = useCallback(() => {
     if (isOpen) {

--- a/src/hooks/useToggleModal.ts
+++ b/src/hooks/useToggleModal.ts
@@ -1,7 +1,5 @@
 import { useCallback } from 'react';
 
-import { useNavigate } from 'react-router-dom';
-
 import { RootState } from '@/store';
 import { closeModal, openModal } from '@/store/slices/modalToggleSlice';
 import { useDispatch, useSelector } from 'react-redux';
@@ -12,7 +10,6 @@ type useToggleModalProps = {
 
 // 모달 여닫기(redux로 state 관리)
 const useToggleModal = ({ modalId }: useToggleModalProps) => {
-  const navigate = useNavigate();
   const isOpen = useSelector((state: RootState) => state.modal[modalId]);
   const dispatch = useDispatch();
 
@@ -22,8 +19,7 @@ const useToggleModal = ({ modalId }: useToggleModalProps) => {
 
   const closeIdModal = useCallback(() => {
     dispatch(closeModal(modalId));
-    navigate(-1);
-  }, [dispatch, modalId, navigate]);
+  }, [dispatch, modalId]);
 
   const toggleModal = useCallback(() => {
     if (isOpen) {

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -1,18 +1,77 @@
-import MainCalendar from '@/components/calendar/MainCalendar';
+import { useState } from 'react';
+
 import * as S from './HomePage.style';
 import ModalFull from '@/components/ui/ModalFull';
+import MainCalendar from '@/components/calendar/MainCalendar';
 import AddScheduleModal from '@/components/add-schedule-modal/AddScheduleModal';
+import EditScheduleModal from '@/components/edit-schedule-modal/EditScheduleModal';
 import { useToggleModal } from '@/hooks/useToggleModal';
-import { ADD_SCHEDULE_MODAL_ID } from '@/constants/constant';
+import { useCalendarEvents } from '@/hooks/useCalendarEvents';
+import {
+  ADD_SCHEDULE_MODAL_ID,
+  EDIT_SCHEDULE_MODAL_ID,
+} from '@/constants/constant';
+import { IEventList } from '@/types/calendar';
 
 const HomePage = () => {
-  const { isOpen } = useToggleModal({ modalId: ADD_SCHEDULE_MODAL_ID });
+  const [selectedSchedule, setSelectedSchedule] = useState<IEventList | null>(
+    null,
+  );
+
+  const { isOpen: isAddModalOpen } = useToggleModal({
+    modalId: ADD_SCHEDULE_MODAL_ID,
+  });
+  const { isOpen: isEditModalOpen, closeIdModal: closeEditModal } =
+    useToggleModal({
+      modalId: EDIT_SCHEDULE_MODAL_ID,
+    });
+  const {
+    handleDateSelect,
+    handleDelete,
+    handleEdit,
+    processedEvents,
+    selectedEvents,
+  } = useCalendarEvents();
+
+  const handleEditSchedule = (schedule: IEventList) => {
+    setSelectedSchedule(schedule);
+  };
+
+  const handleEditing = (
+    eventId: string,
+    updatedSchedule: Partial<IEventList>,
+  ) => {
+    handleEdit(eventId, updatedSchedule);
+    closeEditModal();
+    setSelectedSchedule(null);
+  };
 
   return (
     <S.Container>
-      <MainCalendar />
-      <ModalFull id="add-calendar-modal" isOpen={isOpen} navText="일정 추가">
+      <MainCalendar
+        processedEvents={processedEvents}
+        selectedEvents={selectedEvents}
+        onEditSchedule={handleEditSchedule}
+        onDateSelect={handleDateSelect}
+        onDelete={handleDelete}
+      />
+
+      <ModalFull
+        id={ADD_SCHEDULE_MODAL_ID}
+        isOpen={isAddModalOpen}
+        navText="일정 추가"
+      >
         <AddScheduleModal />
+      </ModalFull>
+      <ModalFull
+        id={EDIT_SCHEDULE_MODAL_ID}
+        isOpen={isEditModalOpen}
+        navText="일정 수정"
+      >
+        <EditScheduleModal
+          schedule={selectedSchedule!}
+          onEdit={handleEditing}
+        />
       </ModalFull>
     </S.Container>
   );

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 
+import { useNavigate } from 'react-router-dom';
+
 import * as S from './HomePage.style';
 import ModalFull from '@/components/ui/ModalFull';
 import MainCalendar from '@/components/calendar/MainCalendar';
@@ -17,6 +19,7 @@ const HomePage = () => {
   const [selectedSchedule, setSelectedSchedule] = useState<IEventList | null>(
     null,
   );
+  const navigate = useNavigate();
 
   const { isOpen: isAddModalOpen } = useToggleModal({
     modalId: ADD_SCHEDULE_MODAL_ID,
@@ -43,6 +46,7 @@ const HomePage = () => {
   ) => {
     handleEdit(eventId, updatedSchedule);
     closeEditModal();
+    navigate(-1);
     setSelectedSchedule(null);
   };
 

--- a/src/types/calendar.ts
+++ b/src/types/calendar.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { Event, ToolbarProps } from 'react-big-calendar';
 
 export type CustomToolbarProps = Pick<ToolbarProps, 'label' | 'onNavigate'>;
@@ -12,4 +13,12 @@ export interface IEventColorProps {
   id: number;
   bgColor: string;
   fontColor: string;
+}
+
+export interface IMainCalendarProps {
+  processedEvents: IEventList[];
+  selectedEvents: IEventList[];
+  onDateSelect: (cellInfo: { start: Date; end: Date }) => void;
+  onEditSchedule: (schedule: IEventList) => void;
+  onDelete: (id: string) => void;
 }

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -4,13 +4,13 @@ import { IEventList } from './calendar';
 export interface ScheduleItemProps {
   schedule: IEventList;
   onDelete: (id: string) => void;
-  onOpenEditModal: (schedule: IEventList) => void;
+  onEditSchedule: (schedule: IEventList) => void;
 }
 
 export interface ScheduleListProps {
   schedules: IEventList[];
   onDelete: (id: string) => void;
-  onOpenEditModal: (schedule: IEventList) => void;
+  onEditSchedule: (schedule: IEventList) => void;
 }
 
 export type EditScheduleModalProps = {


### PR DESCRIPTION
## 🚀 Related Issues

- 이슈 넘버 #106 

## ☑️ Task Details

- 풀모달이 닫힐 때 `navigate(-1)` 적용했어요.
- 풀모달을 HomePage에서 관리하도록 리팩토링했어요. 
- 더 이상 `MainCalendar`에서 풀모달을 관리하지 않아요. 

## 📂 References

- 스크린샷이나 레퍼런스를 넣어주세요!

## 💞 Review Requirements

- `useCalendarEvents`를 MainCalendar와 HomePage에 필요한 것만 가져와 사용하려 했는데 인스턴스 값이 달라서 수정이 제대로 되지 않았어요. 그래서 최상위 컴포넌트에서 받아와 HomePage로 props를 전달해줬어요.

### 👍 navigate?
- 풀모달이 닫힐 때 `closeModal`이 진행되고나서 `navigate(-1)`을 해줬었어요. 그런데 테스트해보다가 이상해서 찾아봤어요.
`handleEditing`에서 `navigate(-1)`을 사용할 때
```js
const handleEditing = (eventId: string, updatedSchedule: Partial<IEventList>) => {
    handleEdit(eventId, updatedSchedule);
    closeEditModal();
    navigate(-1);  // 마지막에 실행됨
    setSelectedSchedule(null);
};
```
위와 같은 경우에는 모든 상태 업데이트가 완료된 후에 navigation이 실행된다고 해요.

`useToggleModal`에서 `closeIdModal`에 `navigate(-1)`을 추가할 때
```js
const closeIdModal = useCallback(() => {
    dispatch(closeModal(modalId));
    navigate(-1);  // 모달 닫기와 거의 동시에 실행됨
}, [dispatch, modalId]);
```
위와 같은 경우에는 모달을 닫는 액션과 navigation이 거의 동시에 실행되기 때문에 다른 상태 업데이트들이 완료되기 전에 네비게이팅이 발생할 수 있어요.

결론적으로 안정적인 방법은 `handleEditing`에 `navigate(-1)`을 사용하는 것이에요.
1. 모든 상태 업데이트가 순차적으로 완료됨을 보장할 수 있어요.
2. 수정 완료 시에만 navigation이 발생하도록 할 수 있어요.