### PR TITLE
#118 [FEAT] 개인 일정이 아닌 근무 일정을 firestore와 연동해 조회하고, 수정은 불가능하도록 합니다. 

### DIFF
--- a/src/api/scheduleApi.ts
+++ b/src/api/scheduleApi.ts
@@ -45,7 +45,7 @@ export const getPersonalScheduleItems = async (
       const data = doc.data();
       events.push({
         eventId: doc.id,
-        title: data.title || '',
+        title: data.title || '개인 일정',
         start: data.start.toDate(),
         end: data.end.toDate(),
         color: {
@@ -90,7 +90,7 @@ export const getWorkScheduleItems = async (
       const data = doc.data();
       events.push({
         eventId: doc.id,
-        title: data.title || '',
+        title: data.title || '근무 일정',
         start: data.start.toDate(),
         end: data.end.toDate(),
         color: {

--- a/src/api/scheduleApi.ts
+++ b/src/api/scheduleApi.ts
@@ -14,6 +14,7 @@ import app from '@/server/firebase/initialize';
 import { IEventList } from '@/types/calendar';
 import { IUserState } from '@/store/slices/userSlice';
 import { arrEventColor } from '@/constants/constant';
+import { ARR_WORK_SCHEDULE_COLOR } from '@/constants/constant';
 
 const db = getFirestore(app);
 dayjs.locale('ko');
@@ -59,6 +60,52 @@ export const getPersonalScheduleItems = async (
     return events;
   } catch (err) {
     console.error('일정 데이터를 가져오는데 실패했어요!', err);
+    throw err;
+  }
+};
+
+// 근무 이벤트 조회
+export const getWorkScheduleItems = async (
+  user: IUserState,
+): Promise<IEventList[]> => {
+  try {
+    if (!user.email) {
+      throw new Error('로그인이 필요합니다.');
+    }
+
+    // 현재 로그인한 유저의 문서 참조
+    const userDocRef = doc(db, 'workSchedules', user.email);
+    // 유저 문서가 존재하는지 확인
+    const userDocSnap = await getDoc(userDocRef);
+
+    if (!userDocSnap.exists()) {
+      return [];
+    }
+
+    const workSchedulesCollectionRef = collection(userDocRef, 'schedules');
+    const querySnapshot = await getDocs(workSchedulesCollectionRef);
+
+    const events: IEventList[] = [];
+    querySnapshot.forEach(doc => {
+      const data = doc.data();
+      events.push({
+        eventId: doc.id,
+        title: data.title || '',
+        start: data.start.toDate(),
+        end: data.end.toDate(),
+        color: {
+          id: data.color?.id || ARR_WORK_SCHEDULE_COLOR[0].id,
+          bgColor: data.color?.bgColor || ARR_WORK_SCHEDULE_COLOR[0].bgColor,
+          fontColor:
+            data.color?.fontColor || ARR_WORK_SCHEDULE_COLOR[0].fontColor,
+        },
+        memo: data.memo || '',
+      });
+    });
+
+    return events;
+  } catch (err) {
+    console.error('근무 일정 데이터를 가져오는데 실패했어요!', err);
     throw err;
   }
 };

--- a/src/components/schedule/schedule-item/ScheduleItem.styles.ts
+++ b/src/components/schedule/schedule-item/ScheduleItem.styles.ts
@@ -9,12 +9,13 @@ export const ScheduleItemWrapper = styled.div`
   }
 `;
 
-export const ScheduleItem = styled.div`
+export const ScheduleItem = styled.div<{ $isWorkSchedule: boolean }>`
   display: flex;
   align-items: center;
   justify-content: space-between;
   padding: var(--spacing-3) 0;
-  cursor: pointer;
+  cursor: ${({ $isWorkSchedule }) =>
+    $isWorkSchedule ? 'not-allowed' : 'pointer'};
 `;
 
 export const ScheduleInfo = styled.div`

--- a/src/components/schedule/schedule-item/ScheduleItem.tsx
+++ b/src/components/schedule/schedule-item/ScheduleItem.tsx
@@ -21,7 +21,11 @@ const ScheduleItem = ({
 
   if (!schedule) return null;
 
+  const isWorkSchedule: boolean =
+    'isWorkSchedule' in schedule && !!schedule.isWorkSchedule;
+
   const handleDelete = () => {
+    if (isWorkSchedule) return;
     onDelete(schedule.eventId);
     setShowDeleteButton(false);
   };
@@ -32,11 +36,13 @@ const ScheduleItem = ({
 
   const handleEdit = (e: React.MouseEvent) => {
     e.stopPropagation();
+    if (isWorkSchedule) return;
     onEditSchedule(schedule);
     openIdModal();
   };
 
   const toggleTrashButton = (event: React.MouseEvent) => {
+    if (isWorkSchedule) return;
     setShowDeleteButton(prev => !prev);
     event.stopPropagation();
   };
@@ -54,28 +60,35 @@ const ScheduleItem = ({
   return (
     <>
       <S.ScheduleItemWrapper>
-        <S.ScheduleItem onClick={handleEdit}>
+        <S.ScheduleItem onClick={handleEdit} $isWorkSchedule={true}>
           <S.ScheduleInfo>
             <S.ColorDot $bgColor={schedule.color.bgColor} />
             <S.ScheduleText>
-              <S.Title>{schedule.title}</S.Title>
+              <S.Title>
+                {schedule.title}
+                {isWorkSchedule && ' (근무)'}
+              </S.Title>
               <S.Date>{formattedDate}</S.Date>
             </S.ScheduleText>
           </S.ScheduleInfo>
 
-          <S.DeleteButton onClick={toggleTrashButton}>
-            <GoTrash size={24} />
-          </S.DeleteButton>
+          {!isWorkSchedule && (
+            <S.DeleteButton onClick={toggleTrashButton}>
+              <GoTrash size={24} />
+            </S.DeleteButton>
+          )}
         </S.ScheduleItem>
 
-        <S.DeleteConfirmation $show={showDeleteButton}>
-          <Button onClick={handleDelete} $variant="danger" $size="sm">
-            삭제하기
-          </Button>
-          <Button onClick={handleCancel} $variant="secondary" $size="sm">
-            취소
-          </Button>
-        </S.DeleteConfirmation>
+        {!isWorkSchedule && (
+          <S.DeleteConfirmation $show={showDeleteButton}>
+            <Button onClick={handleDelete} $variant="danger" $size="sm">
+              삭제하기
+            </Button>
+            <Button onClick={handleCancel} $variant="secondary" $size="sm">
+              취소
+            </Button>
+          </S.DeleteConfirmation>
+        )}
       </S.ScheduleItemWrapper>
     </>
   );

--- a/src/components/schedule/schedule-item/ScheduleItem.tsx
+++ b/src/components/schedule/schedule-item/ScheduleItem.tsx
@@ -60,7 +60,7 @@ const ScheduleItem = ({
   return (
     <>
       <S.ScheduleItemWrapper>
-        <S.ScheduleItem onClick={handleEdit} $isWorkSchedule={true}>
+        <S.ScheduleItem onClick={handleEdit} $isWorkSchedule={isWorkSchedule}>
           <S.ScheduleInfo>
             <S.ColorDot $bgColor={schedule.color.bgColor} />
             <S.ScheduleText>

--- a/src/constants/constant.ts
+++ b/src/constants/constant.ts
@@ -46,6 +46,27 @@ export const arrEventColor = [
   },
 ];
 
+export const ARR_WORK_SCHEDULE_COLOR = [
+  {
+    id: 1,
+    bgColor: '#47663B',
+    fontColor: '#fff',
+    time: 'open',
+  },
+  {
+    id: 2,
+    bgColor: '#7BD3EA',
+    fontColor: '#000',
+    time: 'middle',
+  },
+  {
+    id: 3,
+    bgColor: '#640D5F',
+    fontColor: '#fff',
+    time: 'close',
+  },
+];
+
 export const MOCK_API_DOMAIN = 'https://api.example.com';
 
 export const SALARY_DETAIL_KEY = {

--- a/src/hooks/useCalendarEvents.ts
+++ b/src/hooks/useCalendarEvents.ts
@@ -9,6 +9,7 @@ import {
   getPersonalScheduleItems,
   updatePersonalScheduleItem,
   deletePersonalScheduleItem,
+  getWorkScheduleItems,
 } from '@/api/scheduleApi';
 
 const useCalendarEvents = () => {
@@ -31,8 +32,15 @@ const useCalendarEvents = () => {
       try {
         setIsLoading(true);
         setError(null);
-        const fetchedEvents = await getPersonalScheduleItems(user);
-        setEvents(fetchedEvents);
+        const personalEvents = await getPersonalScheduleItems(user);
+        const workEvents = await getWorkScheduleItems(user);
+
+        const markedWorkEvents = workEvents.map(event => ({
+          ...event,
+          isWorkSchedule: true,
+        }));
+
+        setEvents([...personalEvents, ...markedWorkEvents]);
       } catch (error) {
         setError('일정을 불러오는데 실패했어요!');
         console.error('일정 조회 실패: ', error);


### PR DESCRIPTION
## 🚀 Related Issues

- 이슈 넘버 #118 

## ☑️ Task Details

- 근무 일정 스케줄 조회하는 API를 만들었어요.
- 근무 일정은 수정과 삭제가 안되도록 처리했어요.

## 📂 References

- 스크린샷이나 레퍼런스를 넣어주세요!

## 💞 Review Requirements

- 리뷰 요구사항을 적어주세요!
